### PR TITLE
Enable to run tests for orc file format

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,17 @@ version := "1.0"
 
 scalaVersion := "2.11.12"
 
+/* For oap 0.5.0 package, there are two guava packages.
+ * One is from Spark. The other is from ORC.
+ * Use below strategy to select the first matching guava package.
+ */
+assemblyMergeStrategy in assembly := {
+  case PathList("com", "google", "guava", xs @ _*) => MergeStrategy.first
+  case x =>
+    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    oldStrategy(x)
+}
+
 unmanagedJars in Compile += file("/home/oap/oap/oap-0.4.0-SNAPSHOT.jar")
 unmanagedJars in Compile += file("lib/spark-sql-perf_2.11-0.4.11-SNAPSHOT.jar")
 

--- a/src/main/scala/org/apache/spark/sql/BenchmarkConfig.scala
+++ b/src/main/scala/org/apache/spark/sql/BenchmarkConfig.scala
@@ -167,7 +167,7 @@ trait OrcOnlyConfigSet extends BenchmarkConfigSelector{
   )
 }
 
-trait ParquetOapOrcConfigSet extends BenchmarkConfigSelector{
+trait ParquetVsOapVsOrcConfigSet extends BenchmarkConfigSelector{
   // TODO: choose conf
   def allConfigurations: Seq[BenchmarkConfig] = Seq(
     new BenchmarkConfig()

--- a/src/main/scala/org/apache/spark/sql/BenchmarkConfig.scala
+++ b/src/main/scala/org/apache/spark/sql/BenchmarkConfig.scala
@@ -154,9 +154,30 @@ trait ParquetOnlyConfigSet extends BenchmarkConfigSelector{
   )
 }
 
-trait ParquetVsOapConfigSet extends BenchmarkConfigSelector{
+trait OrcOnlyConfigSet extends BenchmarkConfigSelector{
+  def allConfigurations: Seq[BenchmarkConfig] = Seq(
+    new BenchmarkConfig()
+      .setBenchmarkConfName("Orc w/ index")
+      .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
+      .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true"),
+    new BenchmarkConfig()
+      .setBenchmarkConfName("Orc w/o index")
+      .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
+      .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "false")
+  )
+}
+
+trait ParquetOapOrcConfigSet extends BenchmarkConfigSelector{
   // TODO: choose conf
   def allConfigurations: Seq[BenchmarkConfig] = Seq(
+    new BenchmarkConfig()
+      .setBenchmarkConfName("Orc w/ index")
+      .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
+      .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "true"),
+    new BenchmarkConfig()
+      .setBenchmarkConfName("Orc w/o index")
+      .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "orc")
+      .setBenchmarkConf(BenchmarkConfig.INDEX_ENABLE, "false"),
     new BenchmarkConfig()
       .setBenchmarkConfName("oap w/ index")
       .setBenchmarkConf(BenchmarkConfig.FILE_FORMAT, "oap")
@@ -219,6 +240,7 @@ trait CacheMissConfigSet extends BenchmarkConfigSelector {
       .setSparkConf("spark.sql.oap.oindex.eis.enabled", "false")
   )
 }
+
 trait LocalClusterConfigSet extends BenchmarkConfigSelector {
   // TODO: choose conf
   def allConfigurations: Seq[BenchmarkConfig] = Seq(

--- a/src/main/scala/org/apache/spark/sql/suites/BitmapIndexSuite.scala
+++ b/src/main/scala/org/apache/spark/sql/suites/BitmapIndexSuite.scala
@@ -16,10 +16,10 @@
  */
 package org.apache.spark.sql.suites
 
-import org.apache.spark.sql.{BenchmarkConfig, OapBenchmarkDataBuilder, OapTestSuite, ParquetOapOrcConfigSet}
+import org.apache.spark.sql.{BenchmarkConfig, OapBenchmarkDataBuilder, OapTestSuite, ParquetVsOapVsOrcConfigSet}
 import org.apache.spark.sql.internal.oap.OapConf
 
-object BitmapIndexSuite extends OapTestSuite with ParquetOapOrcConfigSet {
+object BitmapIndexSuite extends OapTestSuite with ParquetVsOapVsOrcConfigSet {
   override protected def getAppName: String = "BtreeIndexBenchmarkSuite"
 
   private val table = "store_sales"

--- a/src/main/scala/org/apache/spark/sql/suites/BitmapIndexSuite.scala
+++ b/src/main/scala/org/apache/spark/sql/suites/BitmapIndexSuite.scala
@@ -16,10 +16,10 @@
  */
 package org.apache.spark.sql.suites
 
-import org.apache.spark.sql.{BenchmarkConfig, OapBenchmarkDataBuilder, OapTestSuite, ParquetVsOapConfigSet}
+import org.apache.spark.sql.{BenchmarkConfig, OapBenchmarkDataBuilder, OapTestSuite, ParquetOapOrcConfigSet}
 import org.apache.spark.sql.internal.oap.OapConf
 
-object BitmapIndexSuite extends OapTestSuite with ParquetVsOapConfigSet {
+object BitmapIndexSuite extends OapTestSuite with ParquetOapOrcConfigSet {
   override protected def getAppName: String = "BtreeIndexBenchmarkSuite"
 
   private val table = "store_sales"

--- a/src/main/scala/org/apache/spark/sql/suites/BtreeIndexSuite.scala
+++ b/src/main/scala/org/apache/spark/sql/suites/BtreeIndexSuite.scala
@@ -19,7 +19,8 @@ package org.apache.spark.sql.suites
 import org.apache.spark.sql._
 import org.apache.spark.sql.internal.oap.OapConf
 
-object BtreeIndexSuite extends OapTestSuite with OapPerfSuiteContext with ParquetOapOrcConfigSet {
+object BtreeIndexSuite
+    extends OapTestSuite with OapPerfSuiteContext with ParquetVsOapVsOrcConfigSet {
   override protected def getAppName: String = "BtreeIndexBenchmarkSuite"
 
   val table = "store_sales"

--- a/src/main/scala/org/apache/spark/sql/suites/BtreeIndexSuite.scala
+++ b/src/main/scala/org/apache/spark/sql/suites/BtreeIndexSuite.scala
@@ -19,7 +19,7 @@ package org.apache.spark.sql.suites
 import org.apache.spark.sql._
 import org.apache.spark.sql.internal.oap.OapConf
 
-object BtreeIndexSuite extends OapTestSuite with OapPerfSuiteContext with ParquetVsOapConfigSet {
+object BtreeIndexSuite extends OapTestSuite with OapPerfSuiteContext with ParquetOapOrcConfigSet {
   override protected def getAppName: String = "BtreeIndexBenchmarkSuite"
 
   val table = "store_sales"


### PR DESCRIPTION
The changes are below:
1. Add the strategy to fix assembly error for guava package in OAP 0.5.0 release
2. Add orc configuration set for bitmap and btree test suites.